### PR TITLE
Add regexp matching and process locking

### DIFF
--- a/hydrascrape/.gitignore
+++ b/hydrascrape/.gitignore
@@ -1,2 +1,2 @@
 *_handled_builds.txt
-
+*.lock

--- a/hydrascrape/.gitignore
+++ b/hydrascrape/.gitignore
@@ -1,2 +1,3 @@
 *_handled_builds.txt
 *.lock
+*.json

--- a/hydrascrape/hydrascrape.py
+++ b/hydrascrape/hydrascrape.py
@@ -10,6 +10,8 @@ import urllib.request
 import gzip
 import subprocess
 import os
+import re
+import filelock
 
 
 def convert_int(str, default = 0):
@@ -25,15 +27,15 @@ debug = convert_int(os.getenv("DEBUG"))
 
 def help():
     print("")
-    print("Usage: python3 hydrascrape.py <server> <project> <jobset> <action>")
+    print("Usage: python3 hydrascrape.py <server> <project regexp> <jobset regexp> <handled builds file> <action>")
     print("")
-    print("Tries to find builds to handle for a specific jobset from a hydra server")
-    print("Already handled builds will be read from <server>_<project>_<jobset>_handled_builds.txt if it exists")
+    print("Tries to find builds to handle for specific projects and jobsets from a hydra server")
+    print("Already handled builds will be read from handled builds file if it exists")
     print("Successfully handled builds (action returned 0) will be added to the handled builds file")
     print("action will be run with all the build information in the environment")
     print("")
     print("For example, check environment variables starting with \"HYDRA_\":")
-    print("python3 hydrascrape.py my.hydra.server myproject myjobset \"env | egrep ^HYDRA_\"")
+    print("python3 hydrascrape.py my.hydra.server myproject \"job.*\" myhydra_handled_builds.txt \"env | egrep ^HYDRA_\"")
     print("")
     sys.exit(0)
 
@@ -47,8 +49,7 @@ def get_page(urlctx, url):
     try:
         response = urllib.request.urlopen(req)
     except HTTPError as error:
-        if debug:
-            print(f"HTTP error: {error}")
+        print(f"HTTP error: {error}", file = sys.stderr)
         return ""
 
     if response.info().get('Content-Encoding') == 'gzip':
@@ -56,17 +57,17 @@ def get_page(urlctx, url):
     elif response.info().get('Content-Encoding') == 'deflate':
         text = response.read()
     elif response.info().get('Content-Encoding'):
-        print('Encoding type unknown')
-        sys.exit(1)
+        print('Encoding type unknown', file = sys.stderr)
+        return ""
     else:
         text = response.read()
 
-    #text = text.decode('utf-8')
     return text
 
 
 def get_builds(urlctx, eval):
-    text = get_page(urlctx, urlctx["evalurl"] + eval)
+    hydra = urlctx['hydraurl']
+    text = get_page(urlctx, f"{hydra}eval/{eval}")
     soup = bs4.BeautifulSoup(text, features="html.parser")
 
     builds = []
@@ -83,10 +84,48 @@ def get_builds(urlctx, eval):
     return builds
 
 
-def update_handled(filename, build):
-    file = open(filename, "a")
-    file.write(f"{build}\n")
-    file.close()
+def get_handled(filename):
+    handled = []
+    try:
+        file = open(filename, "r")
+        file_lines = file.read()
+        file.close()
+
+        shandled = file_lines.split("\n")
+
+        for bs in shandled:
+            if bs != "":
+                ci = convert_int(bs, -1)
+                if ci != -1:
+                    handled.append(ci)
+                else:
+                    print(f"Weird build number in handled builds file: {bs}", file=sys.stderr)
+
+        if debug:
+            print(f"handled = {handled}")
+
+    except FileNotFoundError:
+        if debug:
+            print(f"{filename} not found")
+
+    except PermissionError as pe:
+        print(f"Cannot read {filename}: {pe.strerror}", file = sys.stderr)
+        sys.exit(1)
+
+    return handled
+
+
+def update_handled(filename, handled):
+    handled.sort()
+    try:
+        file = open(filename, "w")
+        for build in handled:
+            file.write(f"{build}\n")
+        file.close()
+
+    except PermissionError as pe:
+        print(f"Cannot update {filename}: {pe.strerror}", file = sys.stderr)
+        sys.exit(1)
 
 
 def get_build_info(urlctx, bnum):
@@ -104,7 +143,8 @@ def get_build_info(urlctx, bnum):
         "Derivation store path",
         "Output store paths",
     ]
-    text = get_page(urlctx, urlctx['buildurl'] + str(bnum))
+    hydra = urlctx['hydraurl']
+    text = get_page(urlctx, f"{hydra}build/{bnum}")
     soup = bs4.BeautifulSoup(text, features="html.parser")
 
     binfo = {}
@@ -177,27 +217,75 @@ def set_env(binfo):
     return env
 
 
-def main(argv):
-    if len(argv) < 4:
-        help()
+def get_projects(urlctx, hidden=False, disabled=False):
+    text = get_page(urlctx, urlctx['hydraurl'])
+    soup = bs4.BeautifulSoup(text, features="html.parser")
 
-    server = argv[0]
-    hydra = f"https://{server}/"
-    project = argv[1]
-    jobset = argv[2]
-    filename = f"{server}_{project}_{jobset}_handled_builds.txt"
-    evalsurl = f"{hydra}jobset/{project}/{jobset}"
-    context = {
-    "evalurl": f"{hydra}eval/",
-    "buildurl": f"{hydra}build/",
-    "headers": {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-               'Accept-Encoding': 'gzip, deflate',
-               'User-Agent': 'hydrascraper.py v1.0'}
-    }
+    projects = soup.find_all("tr", {"class": "project"})
+    hiddens = soup.find_all("span", {"class": "hidden-project"})
+    disableds = soup.find_all("span", {"class": "disabled-project"})
 
+    plist = []
+    for p in projects:
+        plist.append(p.find("a", {"class": "row-link"})["href"].split("/")[-1])
+
+    hlist = []
+    for h in hiddens:
+        hlist.append(h.find("a", {"class": "row-link"})["href"].split("/")[-1])
+
+    dlist = []
+    for d in disableds:
+        dlist.append(d.find("a", {"class": "row-link"})["href"].split("/")[-1])
+
+    if hidden == False:
+        for h in hlist:
+            if h in plist:
+                plist.remove(h)
+
+    if disabled == False:
+        for d in dlist:
+            if d in plist:
+                plist.remove(d)
+
+    if debug:
+        print("Found projects: ", plist)
+
+    return plist
+
+
+def get_jobsets(urlctx, project, disabled=False):
+    hydra = urlctx['hydraurl']
+    text = get_page(urlctx, f"{hydra}project/{project}")
+    soup = bs4.BeautifulSoup(text, features="html.parser")
+
+    jobsets = soup.find_all("tr", {"class": "jobset"})
+    disableds = soup.find_all("span", {"class": "disabled-jobset"})
+
+    jlist = []
+    for j in jobsets:
+        jlist.append(j.find("a", {"class": "row-link"})["href"].split("/")[-1])
+
+    dlist = []
+    for d in disableds:
+        dlist.append(d.find("a", {"class": "row-link"})["href"].split("/")[-1])
+
+    if disabled == False:
+        for d in dlist:
+            if d in jlist:
+                jlist.remove(d)
+
+    if debug:
+        print("Found jobsets: ", jlist)
+
+    return jlist
+
+
+def handle_jobset(context, project, jobset, handled):
+    server = context['server']
+    hydra = context['hydraurl']
     # It is assumed here that all evaluations containing builds that need processing
     # are found on the first page of evaluations listing
-    text = get_page(context, evalsurl)
+    text = get_page(context, f"{hydra}jobset/{project}/{jobset}")
 
     soup = bs4.BeautifulSoup(text, features="html.parser")
 
@@ -209,25 +297,7 @@ def main(argv):
     # Remove duplicates
     builds = list(dict.fromkeys(builds))
 
-    handled = []
-    try:
-        file = open(filename, "r")
-        file_lines = file.read()
-        shandled = file_lines.split("\n")
-        file.close()
-        for bs in shandled:
-            if bs != "":
-                ci = convert_int(bs, -1)
-                if ci != -1:
-                    handled.append(ci)
-                else:
-                    if debug:
-                        print(f"Weird build number in handled builds file: {bs}")
-        if debug:
-            print(f"handled = {handled}")
-    except FileNotFoundError:
-        if debug:
-            print(f"{filename} not found")
+    newbs = []
 
     for i in builds:
         if i not in handled:
@@ -254,21 +324,92 @@ def main(argv):
                 env = set_env(binfo)
                 if debug:
                     print(f"Handling {i} " + "-" * 60)
-                sp = subprocess.run(argv[3], shell=True, env=env)
+                sp = subprocess.run(context['action'], shell=True, env=env)
                 if sp.returncode == 0:
-                    update_handled(filename, i)
+                    newbs.append(i)
                     if debug:
                         print("Handling successful " + "-" * 55)
                 else:
                     if debug:
-                        print(f"{argv[2]} failed with code: {sp.returncode}")
+                        print(f"Action failed with code: {sp.returncode}")
             else:
                 if debug:
                     print(f"Build {i} has failed, just marking as handled")
-                update_handled(filename, i)
+                newbs.append(i)
         else:
             if debug:
                 print(f"Build {i} already handled")
+
+    return newbs
+
+
+def main_locked(argv):
+    server = argv[0]
+    filename = argv[3]
+    context = {
+    "server": server,
+    "hydraurl": f"https://{server}/",
+    "headers": {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                'Accept-Encoding': 'gzip, deflate',
+                'User-Agent': 'hydrascraper.py v1.0'},
+    "action": argv[4],
+    }
+
+    r = []
+    for i in [0,1]:
+        try:
+            r.append(re.compile(argv[i + 1]))
+        except re.error as e:
+            if e.pos != None:
+                print(argv[i + 1], file = sys.stderr)
+                print(" " * e.pos + "^", file = sys.stderr)
+            print(f"Regular expression error: {e.msg}", file = sys.stderr)
+            sys.exit(1)
+
+    handled = get_handled(filename)
+
+    projects = get_projects(context)
+    projects = list(filter(r[0].match, projects))
+    if debug:
+        print("Selected projects: ", projects)
+
+    jobsets = {}
+    for p in projects:
+        jobsets[p] = get_jobsets(context, p)
+
+    for p in projects:
+        jobsets[p] = list(filter(r[1].match, jobsets[p]))
+        if debug:
+            print(f"{p} selected jobsets: {jobsets[p]}")
+
+    for p in projects:
+        project = p
+        for j in jobsets[p]:
+            jobset = j
+            handled += handle_jobset(context, project, jobset, handled)
+
+    update_handled(filename, handled)
+
+
+def main(argv):
+    if len(argv) < 5:
+        help()
+
+    lock = filelock.FileLock(f"{argv[3]}.lock")
+    try:
+        lock.acquire(timeout=0)
+        main_locked(argv)
+
+    except filelock.Timeout as to:
+        if debug:
+            print(f"Unable to get lock {to.lock_file}")
+            print("If no other hydrascrapers are running, check permissions and/or delete the lock file")
+
+    except PermissionError as pe:
+        print(f"Could not aquire {argv[3]}.lock: {pe.strerror}", file = sys.stderr)
+
+    finally:
+        lock.release()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
projects and jobsets can now be selected with regular expressions. You could even handle all builds on a hydra server by setting both project regexp and jobset regexp to ".*"

locking file is used to stop hydrascrape running concurrently for same set of projects/jobsets. Parallel runs are still possible by setting different handled builds file for each.
Just make sure that patterns don't match same jobsets, or builds in those jobsets will be handled several times.

Handled builds file needs to be explicitly given as a parameter now.

Signed-off-by: Tero Tervala <tero.tervala@unikie.com>